### PR TITLE
 feat(ssg): new admin dashboard (replaces SQLAdmin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,20 @@ blog-coeur ssg server --max-posts=1000 --port=8081
 
 #### Admin Web Panel
 
-Manage your blog’s posts through a simple web interface:
+Manage your blog’s posts through a web dashboard (static HTML + REST API):
 
 ```
 blog-coeur ssg admin
 ```
 
-Go to: `http://localhost:8000/admin`
+Go to: `http://localhost:8000/`
+
+**Admin module** — The admin is a single-page app served by the same process. It lets you:
+
+- **Search / list posts:** Choose a database (or "All"), then search by title or leave the search empty and click Search to list posts paginated. Results open in the left panel.
+- **Edit a post:** Click a result to load it. The main area shows two columns: editable fields (title, content, path, date, image) on the left and a live preview on the right. Content supports HTML or Markdown; Markdown is rendered in the preview.
+- **Rich editor:** Toolbar (bold, italic, headings, lists, link) for the content. Use "View source" to switch between WYSIWYG and raw HTML/Markdown; for Markdown posts, the source view shows Markdown.
+- **Update:** Click "Update post" to save changes. The API is REST (GET/PUT); the navbar link "API (Swagger)" opens the interactive docs at `/docs`.
 
 #### Build Static Site
 
@@ -79,7 +86,7 @@ blog-coeur ssg markdown-to-db "./content"
 - HTML Minification
 - Sitemap generation with pagination
 - Hot reload
-- Post management via SQLAlchemyAdmin dashboard (partial)
+- Admin dashboard: search/list posts, rich editor, view source (HTML/Markdown), update via REST API with Swagger at `/docs`
 
  ### TODO List
 
@@ -87,7 +94,6 @@ blog-coeur ssg markdown-to-db "./content"
     - [ ] Documentation about templates
 - [ ] Support to use post Tags
 - [ ] Hot reload v2 - add websocket to auto-refresh the html in the browser
-- [ ] Manage posts - fixes for multiple databases
 
 
 ## Module CMP - Content Machine Processor

--- a/coeur/apps/ssg/admin.py
+++ b/coeur/apps/ssg/admin.py
@@ -1,85 +1,238 @@
-import types
-from coeur.apps.ssg.db import Post, ShardingManager
-from fastapi import FastAPI
-from sqladmin import Admin
-from sqladmin import ModelView
-from sqlalchemy import create_engine
-from sqlalchemy.orm.session import sessionmaker
-import uvicorn
+"""
+Admin web dashboard for SSG: static HTML + REST API to search, get, list (paginated), and update posts.
+Runs with cwd = blog project root (where db/ and config.toml live).
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy import text
+
+from coeur.apps.ssg.db import DatabaseManager, ShardingManager
+from pydantic import BaseModel
 
 
-class UserAdminPostBase(ModelView, model=Post): ...
+class PostUpdateBody(BaseModel):
+    db: int
+    title: str | None = None
+    content: str | None = None
+    content_format: str | None = None
+    path: str | None = None
+    extra: str | None = None
+    date: str | None = None
+    image: str | None = None
 
 
-class AdminPanel:
-    @staticmethod
-    def handler():
+def _row_to_dict(row):
+    """Convert SQLAlchemy Row or sqlite3.Row to dict."""
+    if row is None:
+        return None
+    if hasattr(row, "_mapping"):
+        return dict(row._mapping)
+    return dict(row)
+
+
+class AdminHandler:
+    """Admin web dashboard: serves static UI and REST API for posts (search, get, list, update)."""
+
+    DEFAULT_HOST = "127.0.0.1"
+    DEFAULT_PORT = 8000
+    DB_DIR = "db"
+
+    def __init__(self, host: str = None, port: int = None):
+        self.host = host or self.DEFAULT_HOST
+        self.port = port or self.DEFAULT_PORT
+        self.static_admin = Path(__file__).resolve().parent / "static" / "admin"
+        self._app = FastAPI(title="Coeur SSG Admin")
+        self._register_routes()
+
+    def _register_routes(self):
+        app = self._app
+
+        @app.get("/")
+        def index():
+            index_path = self.static_admin / "index.html"
+            if not index_path.exists():
+                raise HTTPException(status_code=404, detail="Admin static files not found")
+            return FileResponse(index_path)
+
+        if self.static_admin.exists():
+            app.mount("/static", StaticFiles(directory=str(self.static_admin)), name="static")
+
+        @app.get("/api/databases")
+        def api_list_databases():
+            return self._api_list_databases()
+
+        @app.get("/api/posts/search")
+        def api_search_posts(title: str = Query(..., min_length=1)):
+            return self._api_search_posts(title)
+
+        @app.get("/api/posts/by-id")
+        def api_get_post_by_id(uuid: str = Query(...), db: int = Query(...)):
+            return self._api_get_post_by_id(uuid, db)
+
+        @app.get("/api/posts")
+        def api_list_posts(
+            db: str = Query("all"),
+            page: int = Query(1, ge=1),
+            per_page: int = Query(20, ge=1, le=100),
+        ):
+            return self._api_list_posts(db, page, per_page)
+
+        @app.put("/api/posts/{uuid}")
+        def api_update_post(uuid: str, body: PostUpdateBody):
+            return self._api_update_post(uuid, body)
+
+    def _get_databases_sorted(self):
+        """List of sqlite filenames in db/, sorted by shard number (db1, db2, ...)."""
+        files = ShardingManager.get_databases()
+
+        def key(f):
+            base = f.replace(".sqlite", "")
+            try:
+                return int(base.replace("db", ""))
+            except ValueError:
+                return 0
+
+        return sorted(files, key=key)
+
+    def _api_list_databases(self):
+        dbs = self._get_databases_sorted()
+        return [{"index": i, "name": f.replace(".sqlite", "")} for i, f in enumerate(dbs, start=1)]
+
+    def _api_search_posts(self, title: str):
+        union = ShardingManager.generate_union_posts_query()
+        query = f"""
+            SELECT * FROM ({union}) AS u
+            WHERE title LIKE :title
+            ORDER BY date DESC
+            LIMIT 50
         """
-        Initializes and starts a FastAPI application with an admin interface for managing posts from multiple SQLite databases.
+        db = DatabaseManager()
+        try:
+            result = db.session.execute(text(query), {"title": f"%{title}%"})
+            rows = result.fetchall()
+            return [_row_to_dict(r) for r in rows]
+        finally:
+            db.session.close()
 
-        This method dynamically loads all post classes from the ShardingManager and configures
-        the database bindings for each post class. It then creates a FastAPI application and
-        adds a custom Admin view for each post class, allowing users to manage posts via the
-        admin interface.
+    def _api_get_post_by_id(self, uuid: str, db_index: int):
+        dbs = self._get_databases_sorted()
+        if db_index < 1 or db_index > len(dbs):
+            raise HTTPException(status_code=400, detail=f"db must be between 1 and {len(dbs)}")
+        path = os.path.abspath(os.path.join(self.DB_DIR, dbs[db_index - 1]))
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute("SELECT * FROM posts WHERE uuid = ?", (uuid,))
+            row = cur.fetchone()
+            if not row:
+                raise HTTPException(status_code=404, detail="Post not found")
+            return dict(row)
+        finally:
+            conn.close()
 
-        The method performs the following steps:
-        1. Retrieves the post classes from the ShardingManager.
-        2. Configures the database engine bindings for each post class (SQLite database for each).
-        3. Sets up a FastAPI app and an Admin interface with user-specific views for managing posts.
-        4. Enables editing and deletion of posts for a single database or disables it for multiple databases.
-        5. Adds a view to the Admin interface for each post class, defining the columns and features.
-        6. Starts a local development server for the Admin interface at `http://localhost:8000/admin`.
+    def _api_list_posts(self, db: str, page: int, per_page: int):
+        dbs = self._get_databases_sorted()
+        if not dbs:
+            return {"items": [], "total": 0, "page": page, "per_page": per_page}
+        offset = (page - 1) * per_page
 
-        Notes:
-        - The method currently supports one database with the ability to edit/delete posts.
-          Multi-database support for editing and deleting posts is planned for future implementation.
-        - The `count_query` for each post class is a placeholder and needs to be implemented.
+        if db == "all":
+            union = ShardingManager.generate_union_posts_query()
+            dbm = DatabaseManager()
+            try:
+                total = dbm.count_total_posts()
+                query = f"""
+                    SELECT * FROM ({union}) AS u
+                    ORDER BY date DESC
+                    LIMIT :limit OFFSET :offset
+                """
+                result = dbm.session.execute(text(query), {"limit": per_page, "offset": offset})
+                rows = result.fetchall()
+                items = [_row_to_dict(r) for r in rows]
+                return {"items": items, "total": total, "page": page, "per_page": per_page}
+            finally:
+                dbm.session.close()
+        else:
+            try:
+                db_index = int(db)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="db must be a number or 'all'")
+            if db_index < 1 or db_index > len(dbs):
+                raise HTTPException(status_code=400, detail=f"db must be between 1 and {len(dbs)}")
+            path = os.path.abspath(os.path.join(self.DB_DIR, dbs[db_index - 1]))
+            conn = sqlite3.connect(path)
+            conn.row_factory = sqlite3.Row
+            try:
+                cur = conn.execute("SELECT COUNT(*) FROM posts")
+                total = cur.fetchone()[0]
+                cur = conn.execute(
+                    "SELECT * FROM posts ORDER BY date DESC LIMIT ? OFFSET ?",
+                    (per_page, offset),
+                )
+                rows = cur.fetchall()
+                items = [dict(r) for r in rows]
+                return {"items": items, "total": total, "page": page, "per_page": per_page}
+            finally:
+                conn.close()
 
-        Example:
-            To run the application with the admin interface:
-            ```
-            AdminPanel().handler()
-            ```
-        """
-        post_classes = ShardingManager.get_posts_classes()
-        binds = {}
-        for key, post_classe in post_classes.items():
-            binds[post_classe] = create_engine(f"sqlite:///db/db{key}.sqlite")
+    def _api_update_post(self, uuid: str, body: PostUpdateBody):
+        dbs = self._get_databases_sorted()
+        if body.db < 1 or body.db > len(dbs):
+            raise HTTPException(status_code=400, detail=f"db must be between 1 and {len(dbs)}")
+        path = os.path.abspath(os.path.join(self.DB_DIR, dbs[body.db - 1]))
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute("SELECT * FROM posts WHERE uuid = ?", (uuid,))
+            old_row = cur.fetchone()
+            if old_row is None:
+                raise HTTPException(status_code=404, detail="Post not found")
+            old = dict(old_row)
+            updates = {}
+            if body.title is not None:
+                updates["title"] = body.title
+            if body.content is not None:
+                updates["content"] = body.content
+            if body.content_format is not None:
+                updates["content_format"] = body.content_format
+            if body.path is not None:
+                updates["path"] = body.path
+            if body.extra is not None:
+                updates["extra"] = body.extra
+            if body.date is not None:
+                updates["date"] = body.date
+            if body.image is not None:
+                updates["image"] = body.image
+            if not updates:
+                return old
+            title_new = updates.get("title", old.get("title", ""))
+            content_new = updates.get("content", old.get("content", ""))
+            content_old = old.get("content", "")
+            print("--- UPDATE POST ---")
+            print("uuid:", uuid)
+            print("banco: db{}".format(body.db))
+            print("titulo:", title_new)
+            print("conteudo antigo (primeiros 200 chars):", (content_old[:200] + "..." if len(content_old) > 200 else content_old))
+            print("conteudo novo (primeiros 200 chars):", (content_new[:200] + "..." if len(content_new) > 200 else content_new))
+            print("-------------------")
+            set_clause = ", ".join(f"{k} = ?" for k in updates.keys())
+            values = list(updates.values()) + [uuid]
+            conn.execute(f"UPDATE posts SET {set_clause} WHERE uuid = ?", values)
+            conn.commit()
+            cur = conn.execute("SELECT * FROM posts WHERE uuid = ?", (uuid,))
+            return dict(cur.fetchone())
+        finally:
+            conn.close()
 
-        Session = sessionmaker()
-        Session.configure(binds=binds)
+    def handler(self):
+        """Run the admin server (FastAPI + uvicorn)."""
+        import uvicorn
 
-        app = FastAPI()
-        admin = Admin(app=app, session_maker=Session)
-        # @todo: allow edit/delete for multi databases
-        enable_edit_delete = True if len(post_classes.items()) == 1 else False
-        for key, post_classe in post_classes.items():
-            user_admin_post_class = types.new_class(
-                f"UserAdminPostsDb{key}", UserAdminPostBase.__bases__, {"model": post_classe}
-            )
-            user_admin_post_class.name_plural = f"db{key}"
-            user_admin_post_class.column_searchable_list = [
-                Post.uuid,
-                Post.title,
-                Post.path,
-                Post.date,
-            ]
-            user_admin_post_class.column_list = [Post.uuid, Post.title, Post.path, Post.date]
-            user_admin_post_class.column_sortable_list = [Post.title, Post.date]
-            user_admin_post_class.can_create = False
-            user_admin_post_class.can_edit = enable_edit_delete
-            user_admin_post_class.can_delete = enable_edit_delete
-            user_admin_post_class.icon = "fa-solid fa-database"
-            user_admin_post_class.category = "posts by database"
-            # @todo: fix counter by db
-            # user_admin_post_class.count_query = ?
-            admin.add_view(user_admin_post_class)
-
-        print("You can view and manage your posts at http://localhost:8000/admin")
-
-        uvicorn.run(
-            app,
-            host="127.0.0.1",
-            port=8000,
-            log_level="critical",
-        )
+        print("You can view and manage your posts at http://{}:{}/".format(self.host, self.port))
+        uvicorn.run(self._app, host=self.host, port=self.port, log_level="critical")

--- a/coeur/apps/ssg/ssg.py
+++ b/coeur/apps/ssg/ssg.py
@@ -1,7 +1,7 @@
 from coeur.apps.ssg.build import BuildHandler
 from coeur.apps.ssg.markdown import MarkdownHandler
 from coeur.apps.ssg.bootstrap import CreateHandler, ExportTemplates
-from coeur.apps.ssg.admin import AdminPanel
+from coeur.apps.ssg.admin import AdminHandler
 
 import typer
 
@@ -39,6 +39,6 @@ def export_templates():
 
 
 @app.command()
-def admin():
+def admin(port: int = 8000, host: str = "127.0.0.1"):
     """Manage your posts using the web dashboard"""
-    AdminPanel.handler()
+    AdminHandler(host=host, port=port).handler()

--- a/coeur/apps/ssg/static/admin/admin.css
+++ b/coeur/apps/ssg/static/admin/admin.css
@@ -1,0 +1,387 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #f5f5f5;
+}
+
+.navbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.nav-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nav-group label {
+  font-weight: 500;
+}
+
+#search-input {
+  width: 220px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+button:hover {
+  background: #f0f0f0;
+}
+
+button.primary {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+button.primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+#db-select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-width: 100px;
+}
+
+.nav-link {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  color: inherit;
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.nav-link:hover {
+  background: #f0f0f0;
+}
+
+.message {
+  padding: 0.5rem 1rem;
+  margin: 0;
+  min-height: 1.5rem;
+}
+
+.message.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.message.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.main {
+  display: flex;
+  height: calc(100vh - 120px);
+  overflow: hidden;
+}
+
+.results-panel {
+  width: 320px;
+  min-width: 280px;
+  overflow-y: auto;
+  background: #fff;
+  border-right: 1px solid #ddd;
+  padding: 1rem;
+}
+
+.results-panel h2 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+}
+
+#results-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.result-item {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  cursor: pointer;
+  background: #fff;
+  text-align: left;
+  font-size: 13px;
+}
+
+.result-item:hover {
+  background: #f3f4f6;
+  border-color: #2563eb;
+}
+
+.result-item .title {
+  font-weight: 500;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.result-item .meta {
+  font-size: 11px;
+  color: #6b7280;
+  margin-top: 0.25rem;
+}
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pagination button {
+  padding: 0.25rem 0.5rem;
+  font-size: 12px;
+}
+
+.editor-section {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.editor-section h2 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+}
+
+.two-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.col-editor,
+.col-preview {
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.field {
+  margin-bottom: 0.75rem;
+}
+
+.field label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  font-size: 12px;
+}
+
+.field input,
+.field textarea {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 200px;
+}
+
+.format-badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-size: 11px;
+  color: #6b7280;
+  font-weight: normal;
+}
+
+.toggle-source-btn {
+  margin-left: 0.5rem;
+  font-size: 12px;
+  padding: 0.25rem 0.5rem;
+}
+
+.content-editor-wrap {
+  display: block;
+}
+
+.content-source {
+  display: none;
+  width: 100%;
+  min-height: 280px;
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.content-source.show {
+  display: block;
+}
+
+.content-editor-wrap.hide {
+  display: none;
+}
+
+.rich-editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  background: #f9fafb;
+}
+
+.rich-editor-toolbar button {
+  padding: 0.25rem 0.5rem;
+  font-size: 13px;
+  min-width: 28px;
+}
+
+.toolbar-sep {
+  width: 1px;
+  height: 18px;
+  background: #d1d5db;
+  margin: 0 4px;
+}
+
+.rich-editor-body {
+  width: 100%;
+  min-height: 280px;
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 0 0 4px 4px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  overflow-y: auto;
+  outline: none;
+}
+
+.rich-editor-body:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
+.rich-editor-body h2 {
+  font-size: 1.25rem;
+  margin: 0.75rem 0 0.25rem 0;
+}
+
+.rich-editor-body h3 {
+  font-size: 1.1rem;
+  margin: 0.5rem 0 0.25rem 0;
+}
+
+.rich-editor-body ul,
+.rich-editor-body ol {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.preview {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  background: #fafafa;
+  min-height: 300px;
+}
+
+.preview img {
+  max-width: 100%;
+  height: auto;
+}
+
+.preview h1, .preview h2, .preview h3 {
+  margin: 0.75rem 0 0.25rem 0;
+  line-height: 1.3;
+}
+
+.preview h1 { font-size: 1.5rem; }
+.preview h2 { font-size: 1.25rem; }
+.preview h3 { font-size: 1.1rem; }
+
+.preview p {
+  margin: 0.5rem 0;
+}
+
+.preview ul, .preview ol {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.preview code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.preview pre {
+  background: #f3f4f6;
+  padding: 0.75rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+.preview pre code {
+  background: none;
+  padding: 0;
+}
+
+.preview blockquote {
+  border-left: 4px solid #d1d5db;
+  margin: 0.5rem 0;
+  padding-left: 1rem;
+  color: #4b5563;
+}
+
+@media (max-width: 900px) {
+  .two-cols {
+    grid-template-columns: 1fr;
+  }
+}

--- a/coeur/apps/ssg/static/admin/admin.js
+++ b/coeur/apps/ssg/static/admin/admin.js
@@ -1,0 +1,403 @@
+(function () {
+  const API = "/api";
+  let currentPage = 1;
+  let totalPages = 1;
+  const perPage = 20;
+
+  const el = {
+    searchInput: document.getElementById("search-input"),
+    searchBtn: document.getElementById("search-btn"),
+    dbSelect: document.getElementById("db-select"),
+    saveBtn: document.getElementById("save-btn"),
+    message: document.getElementById("message"),
+    resultsPanel: document.getElementById("results-panel"),
+    resultsList: document.getElementById("results-list"),
+    pagination: document.getElementById("pagination"),
+    editorSection: document.getElementById("editor-section"),
+    postUuid: document.getElementById("post-uuid"),
+    postDb: document.getElementById("post-db"),
+    postTitle: document.getElementById("post-title"),
+    postContentFormat: document.getElementById("post-content-format"),
+    formatBadge: document.getElementById("format-badge"),
+    postContent: document.getElementById("post-content"),
+    postContentSource: document.getElementById("post-content-source"),
+    contentEditorWrap: document.getElementById("content-editor-wrap"),
+    toggleSourceBtn: document.getElementById("toggle-source-btn"),
+    postPath: document.getElementById("post-path"),
+    postDate: document.getElementById("post-date"),
+    postImage: document.getElementById("post-image"),
+    preview: document.getElementById("preview"),
+  };
+
+  var isSourceView = false;
+  var rawMarkdown = null;
+
+  function getContentFormat() {
+    return (el.postContentFormat && el.postContentFormat.value) ? el.postContentFormat.value.toLowerCase() : "html";
+  }
+
+  function getEditorContent() {
+    return el.postContent ? el.postContent.innerHTML : "";
+  }
+
+  function setEditorContent(html) {
+    if (el.postContent) el.postContent.innerHTML = html || "";
+  }
+
+  function getContent() {
+    if (isSourceView && el.postContentSource) return el.postContentSource.value;
+    return getEditorContent();
+  }
+
+  function setContent(html) {
+    setEditorContent(html);
+    if (el.postContentSource) el.postContentSource.value = html || "";
+  }
+
+  function toggleSourceView() {
+    var format = getContentFormat();
+    isSourceView = !isSourceView;
+    if (isSourceView) {
+      if (el.postContentSource) {
+        if (format === "md") {
+          if (rawMarkdown !== null) {
+            el.postContentSource.value = rawMarkdown;
+          } else {
+            var md = htmlToMarkdown(getEditorContent());
+            el.postContentSource.value = md;
+            rawMarkdown = md;
+          }
+        } else {
+          el.postContentSource.value = getEditorContent();
+        }
+        el.postContentSource.classList.add("show");
+        updatePreview(el.postContentSource.value, format);
+      }
+      if (el.contentEditorWrap) el.contentEditorWrap.classList.add("hide");
+      if (el.toggleSourceBtn) el.toggleSourceBtn.textContent = "View editor";
+    } else {
+      var sourceVal = el.postContentSource ? el.postContentSource.value : "";
+      if (format === "md") {
+        rawMarkdown = sourceVal;
+        setEditorContent(renderMarkdown(sourceVal));
+      } else {
+        rawMarkdown = null;
+        setEditorContent(sourceVal);
+      }
+      if (el.contentEditorWrap) el.contentEditorWrap.classList.remove("hide");
+      if (el.postContentSource) el.postContentSource.classList.remove("show");
+      if (el.toggleSourceBtn) el.toggleSourceBtn.textContent = "View source";
+      updatePreview(getEditorContent(), "html");
+    }
+  }
+
+  function renderMarkdown(md) {
+    if (typeof marked === "undefined" || !md) return md || "";
+    return (marked.parse || marked)(md);
+  }
+
+  function htmlToMarkdown(html) {
+    if (!html) return "";
+    if (typeof TurndownService === "undefined") return html;
+    try {
+      var td = new TurndownService();
+      return td.turndown(html);
+    } catch (e) {
+      return html;
+    }
+  }
+
+  function showMessage(text, type) {
+    if (el.message) {
+      el.message.textContent = text || "";
+      el.message.className = "message" + (type ? " " + type : "");
+    }
+  }
+
+  function showError(err) {
+    const text = err?.message || err?.detail || String(err);
+    showMessage(text, "error");
+  }
+
+  function showSuccess(text) {
+    showMessage(text, "success");
+  }
+
+  async function fetchJson(url, options = {}) {
+    const res = await fetch(url, {
+      ...options,
+      headers: { "Content-Type": "application/json", ...options.headers },
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.detail || res.statusText);
+    }
+    return res.json();
+  }
+
+  async function loadDatabases() {
+    const list = await fetchJson(API + "/databases");
+    el.dbSelect.innerHTML = '<option value="all">All</option>';
+    list.forEach(({ index, name }) => {
+      const opt = document.createElement("option");
+      opt.value = index;
+      opt.textContent = name;
+      el.dbSelect.appendChild(opt);
+    });
+  }
+
+  function renderResultItem(post) {
+    const div = document.createElement("button");
+    div.type = "button";
+    div.className = "result-item";
+    div.innerHTML =
+      '<span class="title">' +
+      escapeHtml(post.title || "(no title)") +
+      "</span>" +
+      '<span class="meta">db' +
+      post.db +
+      " · " +
+      (post.date || "") +
+      "</span>";
+    div.addEventListener("click", () => loadPost(post.uuid, post.db));
+    return div;
+  }
+
+  function escapeHtml(s) {
+    const div = document.createElement("div");
+    div.textContent = s;
+    return div.innerHTML;
+  }
+
+  async function search() {
+    const title = (el.searchInput && el.searchInput.value) ? el.searchInput.value.trim() : "";
+    if (!title) {
+      currentPage = 1;
+      listPosts();
+      return;
+    }
+    showMessage("Searching…");
+    try {
+      const items = await fetchJson(API + "/posts/search?title=" + encodeURIComponent(title));
+      el.resultsList.innerHTML = "";
+      if (items.length === 0) {
+        el.resultsList.innerHTML = "<p>No results.</p>";
+      } else {
+        items.forEach((post) => el.resultsList.appendChild(renderResultItem(post)));
+      }
+      el.pagination.innerHTML = "";
+      showMessage("");
+    } catch (e) {
+      showError(e);
+    }
+  }
+
+  async function listPosts() {
+    const db = el.dbSelect.value;
+    showMessage("Loading…");
+    try {
+      const data = await fetchJson(
+        API + "/posts?db=" + encodeURIComponent(db) + "&page=" + currentPage + "&per_page=" + perPage
+      );
+      el.resultsList.innerHTML = "";
+      if (data.items.length === 0) {
+        el.resultsList.innerHTML = "<p>No posts.</p>";
+      } else {
+        data.items.forEach((post) => el.resultsList.appendChild(renderResultItem(post)));
+      }
+      totalPages = Math.max(1, Math.ceil(data.total / perPage));
+      renderPagination(data.total, data.page);
+      showMessage("");
+    } catch (e) {
+      showError(e);
+    }
+  }
+
+  function renderPagination(total, page) {
+    el.pagination.innerHTML = "";
+    const prev = document.createElement("button");
+    prev.type = "button";
+    prev.textContent = "Previous";
+    prev.disabled = page <= 1;
+    prev.addEventListener("click", () => {
+      currentPage = page - 1;
+      listPosts();
+    });
+    el.pagination.appendChild(prev);
+    const info = document.createElement("span");
+    info.textContent = "Page " + page + " of " + totalPages + " (" + total + " items)";
+    el.pagination.appendChild(info);
+    const next = document.createElement("button");
+    next.type = "button";
+    next.textContent = "Next";
+    next.disabled = page >= totalPages;
+    next.addEventListener("click", () => {
+      currentPage = page + 1;
+      listPosts();
+    });
+    el.pagination.appendChild(next);
+  }
+
+  function setVal(element, value) {
+    if (element && "value" in element) element.value = value;
+  }
+
+  function getTitleFromPost(post) {
+    return post.title ?? post["title"] ?? "";
+  }
+
+  async function loadPost(uuid, db) {
+    showMessage("Loading…");
+    try {
+      const post = await fetchJson(API + "/posts/by-id?uuid=" + encodeURIComponent(uuid) + "&db=" + db);
+      setVal(el.postUuid, String(post.uuid != null ? post.uuid : ""));
+      setVal(el.postDb, String(post.db != null ? post.db : ""));
+      var titleVal = String(getTitleFromPost(post));
+      setVal(el.postTitle, titleVal);
+      var titleInput = document.getElementById("post-title");
+      if (titleInput && titleInput.value !== titleVal) titleInput.value = titleVal;
+      setVal(el.postPath, String(post.path != null ? post.path : ""));
+      setVal(el.postDate, String(post.date != null ? post.date : ""));
+      setVal(el.postImage, String(post.image != null ? post.image : ""));
+      const format = (post.content_format != null ? post.content_format : "html").toString().toLowerCase();
+      setVal(el.postContentFormat, format);
+      if (el.formatBadge) el.formatBadge.textContent = "Format: " + format.toUpperCase();
+      var contentHtml = post.content != null ? post.content : "";
+      if (format === "md") {
+        rawMarkdown = post.content != null ? post.content : "";
+        contentHtml = renderMarkdown(rawMarkdown);
+      } else {
+        rawMarkdown = null;
+      }
+      setEditorContent(contentHtml);
+      if (el.postContentSource) el.postContentSource.value = format === "md" ? rawMarkdown : contentHtml;
+      isSourceView = false;
+      if (el.contentEditorWrap) el.contentEditorWrap.classList.remove("hide");
+      if (el.postContentSource) el.postContentSource.classList.remove("show");
+      if (el.toggleSourceBtn) el.toggleSourceBtn.textContent = "View source";
+      updatePreview(post.content != null ? post.content : "", format);
+      if (el.editorSection) el.editorSection.hidden = false;
+      if (el.saveBtn) el.saveBtn.disabled = false;
+      showMessage("");
+    } catch (e) {
+      showError(e);
+    }
+  }
+
+  function updatePreview(content, format) {
+    if (content == null) content = getEditorContent();
+    if (format == null) format = el.postContentFormat ? el.postContentFormat.value : "html";
+    var html;
+    if (format === "md") {
+      html = renderMarkdown(content);
+    } else {
+      html = content;
+    }
+    if (el.preview) el.preview.innerHTML = html || "<em>Empty</em>";
+  }
+
+  var savedRange = null;
+
+  function saveSelection() {
+    var sel = window.getSelection();
+    if (!sel.rangeCount || !el.postContent || !el.postContent.contains(sel.anchorNode)) return;
+    savedRange = sel.getRangeAt(0).cloneRange();
+  }
+
+  function restoreSelection() {
+    if (!savedRange || !el.postContent) return false;
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(savedRange);
+    return true;
+  }
+
+  if (el.postContent) {
+    el.postContent.addEventListener("input", function () {
+      rawMarkdown = null;
+      updatePreview(getEditorContent(), "html");
+    });
+    el.postContent.addEventListener("blur", () => updatePreview(getEditorContent(), "html"));
+    el.postContent.addEventListener("mouseup", saveSelection);
+    el.postContent.addEventListener("keyup", saveSelection);
+  }
+  if (el.postContentSource) {
+    el.postContentSource.addEventListener("input", function () {
+      if (isSourceView) updatePreview(this.value, getContentFormat());
+    });
+  }
+  if (el.toggleSourceBtn) {
+    el.toggleSourceBtn.addEventListener("click", toggleSourceView);
+  }
+
+  document.querySelectorAll(".rich-editor-toolbar button").forEach(function (btn) {
+    var cmd = btn.getAttribute("data-cmd");
+    if (cmd === "createLink") {
+      btn.addEventListener("mousedown", function () { saveSelection(); });
+    }
+    btn.addEventListener("click", function (e) {
+      e.preventDefault();
+      var arg = btn.getAttribute("data-arg") || null;
+      if (cmd === "createLink") {
+        var url = prompt("URL do link:", "https://");
+        if (!url || !(url = url.trim())) return;
+        el.postContent.focus();
+        restoreSelection();
+        document.execCommand(cmd, false, url);
+      } else {
+        el.postContent.focus();
+        document.execCommand(cmd, false, arg);
+      }
+      updatePreview(getEditorContent(), "html");
+    });
+  });
+
+  document.getElementById("save-btn").addEventListener("click", async () => {
+    var uuidEl = el.postUuid || document.getElementById("post-uuid");
+    var dbEl = el.postDb || document.getElementById("post-db");
+    var titleEl = el.postTitle || document.getElementById("post-title");
+    var pathEl = el.postPath || document.getElementById("post-path");
+    var dateEl = el.postDate || document.getElementById("post-date");
+    var imageEl = el.postImage || document.getElementById("post-image");
+    var uuid = uuidEl ? uuidEl.value : "";
+    var db = dbEl ? parseInt(dbEl.value, 10) : 0;
+    if (!uuid || !db) return;
+    var fmt = getContentFormat();
+    var body = {
+      db: db,
+      title: titleEl ? titleEl.value : "",
+      content: getContent(),
+      content_format: (fmt === "md" && isSourceView) ? "md" : "html",
+      path: pathEl ? pathEl.value : "",
+      date: dateEl ? dateEl.value : "",
+      image: imageEl ? imageEl.value : "",
+    };
+    showMessage("Saving…");
+    try {
+      var res = await fetch(API + "/posts/" + encodeURIComponent(uuid), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        var data = await res.json().catch(function () { return {}; });
+        throw new Error(data.detail || res.statusText);
+      }
+      showSuccess("Post updated.");
+    } catch (e) {
+      showError(e);
+    }
+  });
+
+  el.searchBtn.addEventListener("click", search);
+  el.searchInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") search();
+  });
+
+  loadDatabases()
+    .then(function () {
+      currentPage = 1;
+      listPosts();
+    })
+    .catch(showError);
+})();

--- a/coeur/apps/ssg/static/admin/index.html
+++ b/coeur/apps/ssg/static/admin/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coeur SSG Admin</title>
+  <link rel="stylesheet" href="/static/admin.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/turndown/dist/turndown.min.js"></script>
+</head>
+<body>
+  <nav class="navbar">
+    <div class="nav-group">
+      <label for="db-select">Database:</label>
+      <select id="db-select">
+        <option value="all">All</option>
+      </select>
+    </div>
+    <div class="nav-group">
+      <input type="text" id="search-input" placeholder="Search by title" />
+      <button type="button" id="search-btn">Search</button>
+    </div>
+    <button type="button" id="save-btn" class="primary" disabled>Update post</button>
+    <a href="/docs" target="_blank" rel="noopener" class="nav-link">API (Swagger)</a>
+  </nav>
+
+  <div id="message" class="message" aria-live="polite"></div>
+
+  <main class="main">
+    <aside id="results-panel" class="results-panel">
+      <h2>Results</h2>
+      <div id="results-list"></div>
+      <div id="pagination" class="pagination"></div>
+    </aside>
+
+    <section id="editor-section" class="editor-section" hidden>
+      <div class="two-cols">
+        <div class="col-editor">
+          <h2>Edit</h2>
+          <input type="hidden" id="post-uuid" />
+          <input type="hidden" id="post-db" />
+          <input type="hidden" id="post-content-format" />
+          <div class="field">
+            <label for="post-title">Title</label>
+            <input type="text" id="post-title" />
+          </div>
+          <div class="field field-content">
+            <label for="post-content">Content</label>
+            <span class="format-badge" id="format-badge"></span>
+            <button type="button" id="toggle-source-btn" class="toggle-source-btn" title="Toggle between editor and source code">View source</button>
+            <div id="content-editor-wrap" class="content-editor-wrap">
+              <div class="rich-editor-toolbar" role="toolbar">
+                <button type="button" data-cmd="bold" title="Bold">B</button>
+                <button type="button" data-cmd="italic" title="Italic">I</button>
+                <button type="button" data-cmd="underline" title="Underline">U</button>
+                <span class="toolbar-sep"></span>
+                <button type="button" data-cmd="formatBlock" data-arg="h2" title="Heading 2">H2</button>
+                <button type="button" data-cmd="formatBlock" data-arg="h3" title="Heading 3">H3</button>
+                <button type="button" data-cmd="formatBlock" data-arg="p" title="Paragraph">P</button>
+                <span class="toolbar-sep"></span>
+                <button type="button" data-cmd="insertUnorderedList" title="List">• List</button>
+                <button type="button" data-cmd="insertOrderedList" title="Numbered list">1. List</button>
+                <span class="toolbar-sep"></span>
+                <button type="button" data-cmd="createLink" title="Link">Link</button>
+              </div>
+              <div id="post-content" class="rich-editor-body" contenteditable="true"></div>
+            </div>
+            <textarea id="post-content-source" class="content-source" rows="20" spellcheck="false" placeholder="HTML source code"></textarea>
+          </div>
+          <div class="field">
+            <label for="post-path">Path</label>
+            <input type="text" id="post-path" />
+          </div>
+          <div class="field">
+            <label for="post-date">Date</label>
+            <input type="text" id="post-date" />
+          </div>
+          <div class="field">
+            <label for="post-image">Image URL</label>
+            <input type="text" id="post-image" />
+          </div>
+        </div>
+        <div class="col-preview">
+          <h2>Preview</h2>
+          <div id="preview" class="preview"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="/static/admin.js"></script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blog-coeur"
-version = "0.0.18"
+version = "0.0.19"
 description = "Coeur - static site management"
 authors = ["David Silva <srdavidsilva@gmail.com>"]
 readme = "README.md"
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-typer = {extras = ["all"], version = "^0.12.3"}
+typer = {extras = ["all"], version = "^0.24.0"}
 toml = "^0.10.2"
 sqlalchemy = "^2.0.30"
 jinja2 = "^3.1.4"
@@ -31,6 +31,7 @@ sqladmin = "^0.20.1"
 fastapi = "^0.115.5"
 uvicorn = "^0.32.0"
 atproto = "^0.0.55"
+rich = "^14.3.2"
 
 [tool.poetry.scripts]
 blog-coeur = "coeur.main:app"


### PR DESCRIPTION
## New SSG Admin (replaces SQLAdmin)

### Summary
Replaces the SQLAdmin-based admin panel with a custom dashboard: static HTML + REST API, served by the same `blog-coeur ssg admin` command.

### Changes
- **Admin module** (`coeur/apps/ssg/admin.py`): `AdminHandler` class with config (host, port, static path). Uses `ShardingManager` and `DatabaseManager` for union queries; sqlite3 for single-shard read/update.
- **REST API**: `GET /api/databases`, `GET /api/posts/search?title=`, `GET /api/posts/by-id?uuid=&db=`, `GET /api/posts?db=&page=&per_page=`, `PUT /api/posts/{uuid}`. Swagger at `/docs`.
- **Frontend** (`static/admin/`): Single-page app with database selector, search (empty = list paginated), results list, two-column editor (editable + preview), rich editor (bold, italic, headings, lists, link), "View source" toggle (HTML/Markdown; Turndown for HTML→MD when editing in WYSIWYG). Labels in English. Link to API (Swagger) in navbar.
- **CLI**: `blog-coeur ssg admin` instantiates `AdminHandler(host=host, port=port).handler()` (same pattern as other commands).
- **Removed**: `admin.py` (old SQLAdmin panel).
- **Docs**: README updated with Admin module section (URL `http://localhost:8000/`, features, Swagger).
- **Misc**: Update post button fix (missing `postTitle` in `el`), log on update (uuid, db, title, content old/new snippet in terminal).